### PR TITLE
Fix error on first time run - check for empty list (Closes: Issue 1)

### DIFF
--- a/lwn2pocket.py
+++ b/lwn2pocket.py
@@ -76,10 +76,11 @@ def main():
     already_in_pocket = p.get(domain="lwn.net", detailType="simple",
                               state="all")
     articles_already_pushed = set()
-    for entry_id, entry in already_in_pocket[0]['list'].items():
-        m = RE_SUBSCRIBER_LINK.match(entry['given_url'])
-        if m:
-            articles_already_pushed.add(m.group(1))
+    if already_in_pocket[0]['list']:
+        for entry_id, entry in already_in_pocket[0]['list'].items():
+            m = RE_SUBSCRIBER_LINK.match(entry['given_url'])
+            if m:
+                articles_already_pushed.add(m.group(1))
 
     for line in bigpage.text.split("\n"):
         m = RE_SUBSCRIBER_LINK_FORM.search(line)


### PR DESCRIPTION
Hi
the following patch fixes the problem I mentioned in issue 1: If the program is run the first time, the list returned is empty and .items does not work. The patch simply checks for an empty list and only checks for already committed items in case there are some.

All the best

Norbert
